### PR TITLE
Does not crash if there is an error (ValueError)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,7 @@
 # NP2Dumper
-Dumps NP2 data.
-
-### Setup
-If you don't give a damn about security, you can just skip to the second use case below.  
-`$ python setup.py`  
-Then follow the straight-forward instructions.  
-This will generate a file called `np2d-config.ini` in your current directory.
+Dumps NP2 game state and intel data.
 
 ### Usage
-
-##### Recommended
+`$ pip install requests`  
+`$ python setup.py`  
 `$ python dumper.py`  
-You will need to have ran the setup completely for this method to work.
-
-##### Not Recommended
-`$ python dumper.py -u username -p password -g game_number [-t refresh_interval_sec]`
-

--- a/dumper.py
+++ b/dumper.py
@@ -171,11 +171,14 @@ def main():
     refresh_interval = dic['refresh_interval']
 
     while True:
-        state = get_game_state(cookies, dic['game_number'])
-        dump_state_file(state, dic['game_number'])
-        
-        intel = get_intel_data(cookies, dic['game_number'])
-        dump_intel_file(intel, dic['game_number'])
+        try:
+            state = get_game_state(cookies, dic['game_number'])
+            dump_state_file(state, dic['game_number'])
+            
+            intel = get_intel_data(cookies, dic['game_number'])
+            dump_intel_file(intel, dic['game_number'])
+        except ValueError:
+            print "ValueError was caught; ignoring..."
 
         print "Waiting {0} seconds until next bowel movement...".format(refresh_interval)
         time.sleep(float(refresh_interval))


### PR DESCRIPTION
This usually happened when there was a new turn.

Updates README
- adds step: `pip install requests`
- no longer mentions the not-recommended usage
